### PR TITLE
docs: add last modify date query from github by GIT_TOKEN(1 year expi…

### DIFF
--- a/apps/web/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/docs/[[...slug]]/page.tsx
@@ -2,6 +2,8 @@ import { getPage, getPages } from '@/app/source';
 import type { Metadata } from 'next';
 import { DocsPage, DocsBody } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
+import { getGithubLastEdit } from 'fumadocs-core/server'
+import { resolve } from 'url';
 
 export default async function Page({
   params,
@@ -16,8 +18,19 @@ export default async function Page({
 
   const MDX = page.data.exports.default;
 
+  const lastEditDate = await getGithubLastEdit({
+    owner: 'ai-glimpse',
+    repo: 'website',
+    // example: "content/docs/index.mdx"
+    path: resolve('apps/web/content/docs/', page.file.path),
+    token: `Bearer ${process.env.GIT_TOKEN}`
+  });
+
   return (
-    <DocsPage toc={page.data.exports.toc} full={page.data.full}>
+    <DocsPage
+      {...(lastEditDate ? { lastUpdate: new Date(lastEditDate) } : {})}
+      toc={page.data.exports.toc}
+      full={page.data.full}>
       <DocsBody>
         <h1>{page.data.title}</h1>
         <MDX />


### PR DESCRIPTION
https://fumadocs.vercel.app/docs/headless/utils/git-last-edit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to display the last edit date of documents from a GitHub repository within the documentation pages.
  
- **Enhancements**
	- Improved user experience by providing relevant document update information alongside the existing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->