### PR TITLE
docs: add edit on github button

### DIFF
--- a/apps/web/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/docs/[[...slug]]/page.tsx
@@ -2,8 +2,11 @@ import { getPage, getPages } from '@/app/source';
 import type { Metadata } from 'next';
 import { DocsPage, DocsBody } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
-import { getGithubLastEdit } from 'fumadocs-core/server'
+import { getGithubLastEdit } from 'fumadocs-core/server';
 import { resolve } from 'url';
+import { cn } from '@/app/utils/cn';
+import { buttonVariants } from '@/app/components/blog/button';
+import { Edit } from 'lucide-react';
 
 export default async function Page({
   params,
@@ -16,6 +19,25 @@ export default async function Page({
     notFound();
   }
 
+  const path = `apps/web/content/docs/${page.file.path}`;
+  const footer = (
+    <a
+      href={`https://github.com/ai-glimpse/website/blob/main/${path}`}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={cn(
+        buttonVariants({
+          variant: 'secondary',
+          size: 'sm',
+          className: 'text-xs gap-1.5',
+        })
+      )}
+    >
+      <Edit className="size-3" />
+      Edit on Github
+    </a>
+  );
+
   const MDX = page.data.exports.default;
 
   const lastEditDate = await getGithubLastEdit({
@@ -23,14 +45,19 @@ export default async function Page({
     repo: 'website',
     // example: "content/docs/index.mdx"
     path: resolve('apps/web/content/docs/', page.file.path),
-    token: `Bearer ${process.env.GIT_TOKEN}`
+    token: `Bearer ${process.env.GIT_TOKEN}`,
   });
 
   return (
     <DocsPage
       {...(lastEditDate ? { lastUpdate: new Date(lastEditDate) } : {})}
       toc={page.data.exports.toc}
-      full={page.data.full}>
+      full={page.data.full}
+      tableOfContent={{
+        footer,
+      }}
+      tableOfContentPopover={{ footer }}
+    >
       <DocsBody>
         <h1>{page.data.title}</h1>
         <MDX />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a footer link for users to edit documentation directly on GitHub, enhancing accessibility.
	- Improved integration of the footer into the documentation page, offering a more cohesive user experience.

- **Bug Fixes**
	- Maintained the logic for displaying the last edit date from GitHub, ensuring relevant update information is shown.

- **Style**
	- Enhanced visual consistency of the UI with updated styling for the footer link and button variants. 

- **Chores**
	- Implemented minor formatting adjustments for code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->